### PR TITLE
cp: fix uninitialized 'locus' read in backwardAlgorithm initialization

### DIFF
--- a/cp/ChromoPainterSampler.c
+++ b/cp/ChromoPainterSampler.c
@@ -192,9 +192,9 @@ void  backwardAlgorithm(int finalrun,int ndonorpops,int ind_val,double Alphasum,
   for(i=0; i < *p_Nhaps; i++)
     {
       
-	  if(newh[locus]==9) {
+	  if(newh[(*p_Nloci-1)]==9) {
 	    ObsStateProb=1.0;
-	  }else if(newh[locus]==8) {
+	  }else if(newh[(*p_Nloci-1)]==8) {
 	    ObsStateProb = (1-SMALL_NUM) * (newh[(*p_Nloci-1)] == existing_h[i][(*p_Nloci-1)]) + SMALL_NUM * (newh[(*p_Nloci-1)] != existing_h[i][(*p_Nloci-1)]);
 	  }else{
 	    ObsStateProb = (1-MutProb_vec[i]) * (newh[(*p_Nloci-1)] == existing_h[i][(*p_Nloci-1)]) + MutProb_vec[i] * (newh[(*p_Nloci-1)] != existing_h[i][(*p_Nloci-1)]);


### PR DESCRIPTION
## Summary

The backward-pass **initialization** loop in `backwardAlgorithm` selects its `ObsStateProb` branch on `newh[locus]`, but `locus` is only *declared* at function entry -- it is not *assigned* until the main backward loop further down. So these two guards read `newh` at an **indeterminate index**: undefined behavior, and a possible out-of-bounds read or wrong allele code for the final locus.

The branch *bodies* in the same block already index with the explicit last locus `(*p_Nloci-1)` -- mirroring how the forward pass (`InitialiseForward`) handles locus 0 -- so only the two guard conditions had the wrong index. The fix uses `(*p_Nloci-1)` in the guards to match (2 lines).

## Impact

In practice the output is unaffected: the indeterminate `newh[locus]` almost always reads a value that is neither `8` nor `9`, so the `else` branch -- which already used the correct `(*p_Nloci-1)` index -- runs. But it is a genuine uninitialized read (GCC `-Wmaybe-uninitialized`), and an out-of-bounds access is possible depending on what `locus` happens to hold.

## Verification

- `-Wmaybe-uninitialized` for `locus` here: **1 -> 0** warnings (gcc 11/15, `-O2 -Wall`).
- **Output byte-identical** before/after on the in-repo `examples/example2` all-vs-all painting: `chunkcounts`, `chunklengths`, `regionchunkcounts`, `regionsquaredchunkcounts`, `mutationprobs`, `prop`, and `EMprobs` all match.
