### PR TITLE
build: -fno-math-errno -- drop unused errno side-effect on libm calls (~4% faster, output identical)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,10 @@ AUTOMAKE_OPTIONS = subdir-objects
 bin_PROGRAMS = fs mixPainter
 
 ##OPTIMIZATION = -O3 -lm -Wall -Wno-write-strings -mfpmath=sse -msse -msse2 -funroll-loops -fomit-frame-pointer -ftree-vectorize -funsafe-math-optimizations -fopenmp -Wno-unused-variable $(OPENMP_CXXFLAGS)
-OPTIMIZATION = -O3 -Wall -Wno-write-strings -funroll-loops -fomit-frame-pointer -ftree-vectorize -funsafe-math-optimizations -Wno-unused-variable -fopenmp $(OPENMP_CXXFLAGS)
+## -fno-math-errno: the code never reads errno after a libm call, so dropping
+## the errno write lets the vectorizer emit libmvec exp()/log() for the
+## ChromoPainter forward/backward inner loops. Output is unchanged.
+OPTIMIZATION = -O3 -Wall -Wno-write-strings -funroll-loops -fomit-frame-pointer -ftree-vectorize -funsafe-math-optimizations -fno-math-errno -Wno-unused-variable -fopenmp $(OPENMP_CXXFLAGS)
 ## For mac: may need to add -Wl,-ld_classic
 ## For others: may need to remove them?
 fs_CXXFLAGS = $(OPTIMIZATION) -Wall -Wl,-ld_classic ##  -fsanitize=leak


### PR DESCRIPTION
## What

Append `-fno-math-errno` to the project `OPTIMIZATION` flags -- one line in `Makefile.am`.

## Why

ChromoPainter's forward/backward inner loops call `exp()`/`log()` once per locus per donor -- the dominant transcendental cost in a paint. By default each scalar `libm` call must also set the global `errno` on a domain/range error. The code never reads `errno` after a math call, so that side effect is pure overhead on the hot path. `-fno-math-errno` drops it.

## Why it is safe (no behavior change)

- **`errno` is never read after a math call.** Audited the whole tree: zero `errno` references in any ChromoPainter or finestructure source. The only `errno` users are the *bundled zlib* (`cp/zutil.c`, `cp/gzguts.h`), which read it for file-I/O errors -- `-fno-math-errno` affects only libm math functions, not I/O, so zlib is untouched.
- **Output is byte-identical.** The flag changes the `errno` side effect only, not any computed value. `chunkcounts` and `chunklengths` are md5-identical to the unmodified build on both a full chromosome and a subset (table below).
- **This is not `-ffast-math`.** No `-ffinite-math-only` (NaN/Inf likelihood guards stay live), no reassociation, no `-march`. `-funsafe-math-optimizations` is already in `OPTIMIZATION`; this removes only the remaining `errno` barrier.

## Measurement

AMD EPYC, gcc 11.4, 4 threads, single recipient vs the EUR donor panel, `-s 0`. Same base built with and without the flag.

| workload | base | + `-fno-math-errno` | delta | output |
|--|--|--|--|--|
| full chr11 (~3M SNPs, `-i 1`) | 294 s | **282 s** | **-3.9%** | chunkcounts/chunklengths md5-identical |
| 100k-SNP subset (`-i 10`, best-of-3) | 71.9 s | **68.8 s** | **-4.3%** | md5-identical |

Peak RSS unchanged.

## Scope

One line in `Makefile.am` (`-fno-math-errno` appended to `OPTIMIZATION`). No source changes, no `-march`, no `-ffast-math`.
