### PR TITLE
build: set -Wl,-ld_classic only on macOS (Linux/BSD link out of the box)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,9 +11,9 @@ bin_PROGRAMS = fs mixPainter
 ## the errno write lets the vectorizer emit libmvec exp()/log() for the
 ## ChromoPainter forward/backward inner loops. Output is unchanged.
 OPTIMIZATION = -O3 -Wall -Wno-write-strings -funroll-loops -fomit-frame-pointer -ftree-vectorize -funsafe-math-optimizations -fno-math-errno -Wno-unused-variable -fopenmp $(OPENMP_CXXFLAGS)
-## For mac: may need to add -Wl,-ld_classic
-## For others: may need to remove them?
-fs_CXXFLAGS = $(OPTIMIZATION) -Wall -Wl,-ld_classic ##  -fsanitize=leak
+## $(LD_CLASSIC) is -Wl,-ld_classic on macOS (the Xcode 15+ linker needs the
+## classic linker) and empty elsewhere; configure sets it from the host type.
+fs_CXXFLAGS = $(OPTIMIZATION) -Wall $(LD_CLASSIC) ##  -fsanitize=leak
 ## The ChromoPainter inner-loop OpenMP pragmas live in *.c files, so the
 ## same -fopenmp + -O3 + vectorize flags need to flow into the C compile
 ## rule, not just the C++ one. Without fs_CFLAGS, the .c sources compile

--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@ AC_INIT([fs], [4.1.0], [dan.lawson@bristol.ac.uk],
              [fs], [http://www.paintmychromosomes.com])
 AC_PREREQ([2.59])
 AC_CONFIG_AUX_DIR(config)
+AC_CANONICAL_HOST
 AM_INIT_AUTOMAKE([foreign 1.10 -Wall no-define])
 AC_CONFIG_HEADERS([config.h])
 AC_LANG(C++)
@@ -23,6 +24,15 @@ AC_CONFIG_MACRO_DIR([m4])
 
 AC_OPENMP
 AC_SUBST(AM_CXXFLAGS,"$OPENMP_CXXFLAGS")
+
+# The Apple linker (Xcode 15+) needs -ld_classic; GNU ld rejects it (it reads
+# -ld_classic as a request to link libd_classic and fails to find it). Set the
+# flag only on macOS so non-Apple hosts link out of the box.
+case "$host_os" in
+  darwin*) LD_CLASSIC="-Wl,-ld_classic" ;;
+  *)       LD_CLASSIC="" ;;
+esac
+AC_SUBST([LD_CLASSIC])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
## Summary

`fs_CXXFLAGS` hard-codes `-Wl,-ld_classic`. The Apple linker (Xcode 15+) needs it,
but **GNU ld rejects it** - it reads `-ld_classic` as a request to link
`libd_classic` and fails the link with `cannot find -ld_classic`. So a clean
Linux/BSD build of `fs` fails at link, and the workaround was to hand-edit the
flag out (the comment above the line already said so: "For others: may need to
remove them?").

This makes the flag host-conditional instead:

- `configure.ac`: add `AC_CANONICAL_HOST` and set `LD_CLASSIC = -Wl,-ld_classic`
  on `darwin*`, empty elsewhere (`AC_SUBST`).
- `Makefile.am`: `fs_CXXFLAGS = $(OPTIMIZATION) -Wall $(LD_CLASSIC)`.

macOS builds are unchanged; Linux/BSD builds link out of the box. Build-config
only - no source or behaviour change.

## Validated on both hosts

- **macOS** (`host_os=darwin25.5.0`): `configure` sets `LD_CLASSIC = -Wl,-ld_classic`;
  `fs_CXXFLAGS` carries the flag exactly as before.
- **Linux** (`host_os=linux-gnu`): `configure` sets `LD_CLASSIC` empty; a clean
  `autoreconf -i && ./configure && make` links and runs `fs` with **no manual
  edit** (previously this failed at link with `cannot find -ld_classic`).
