### PR TITLE
cp: skip the unused per-SNP allele-count scan in loglik

### DIFF
--- a/cp/ChromoPainterSampler.c
+++ b/cp/ChromoPainterSampler.c
@@ -727,7 +727,12 @@ int loglik(struct copyvec_t *Copyvec, struct donor_t *Donors, struct data_t *Dat
 	}
       }
 
-      int * allelic_type_count_vec=getallelic_type_count_vec(Data);
+      /* getallelic_type_count_vec(Data) is an O(N*K) per-SNP allele-count scan whose
+         result sampler() never reads (cf. its own comment "this is NOT ever used") -
+         it was ~15-19% of a chr-scale paint. Skip the dead scan; sampler ignores the
+         argument (free(NULL) below is a no-op). The function is retained for the day
+         the default-mutation-rate use it was written for is wired up. */
+      int * allelic_type_count_vec=NULL;
 
       fprintf(Par->out,"Processing Recipient number %d, named %s\n",m+1,Donors->reciplabels[m]);
       if(Outfiles->usingFile[2]) fprintf(Outfiles->fout3,"EMPAR for %s\n",Donors->reciplabels[m]);


### PR DESCRIPTION
## Summary

`loglik()` runs `getallelic_type_count_vec(Data)` once per recipient - an O(N*K) per-SNP allele-count scan - but never reads the result. The function's own comment says so:

> this is NOT every used, but perhaps should be to get default mutation rate correct

`sampler()` takes the vector as a parameter and never touches it; the only other references are the call, the pass-through, and a `free()`.

This passes `NULL` instead of running the scan. `sampler()` ignores the argument and `free(NULL)` is a no-op, so **output is byte-identical on every path** (dense and `-fold`) - the value was never consumed.

## Why it matters

Profiling a chromosome-scale paint, this dead scan was ~15-19% of wall-clock. It is the same pure overhead on the dense and fold paths.

## Scope

Only the unconditional call in the hot loop is removed. The `getallelic_type_count_vec` definition stays, for the default-mutation-rate calculation it was written for if that is ever wired up.

## Verification

- Output byte-identical before and after (the result was unused).
- `make check` passes.
