### PR TITLE
cp/fold: cache-block the donor transpose

### DIFF
--- a/cp/ChromoPainterFold.c
+++ b/cp/ChromoPainterFold.c
@@ -391,8 +391,22 @@ void cpfold_perpop(signed char *newh, signed char **existing_h, int nhaps, int n
       free(rep); }
     /* locus-major donor buffer from existing_h (hap-major), rebuilt every call. */
     donors=cf_xmalloc((size_t)N*K);
-    for(int i=0;i<K;i++){ signed char *row=existing_h[i];
-        for(int l=0;l<N;l++) donors[(size_t)l*K+i]=(uint8_t)row[l]; }
+    /* hap-major existing_h -> locus-major donors. Cache-blocked: parallelize over
+       disjoint locus tiles (no false sharing on the shared donors buffer) and tile the
+       donor dimension so writes to donors[l*K + ib..ie] land contiguously (one cache
+       line filled at a time) instead of strided by K. The naive strided-write transpose
+       was ~half the chr-scale fold wall-clock. Output is byte-identical. */
+    /* Tile sizes: TI=64 is one cache line, so the strided donor writes fill whole
+       lines; TL=512 keeps the read block (TI*TL = 32 KiB) inside L1. Wall-clock is
+       flat across TL in 256..4096 on tested hardware (a modern L2 holds the block at
+       any of these), so this is a robustness choice sized to the smallest common L1,
+       not a machine-tuned constant. */
+    { const int TL=512, TI=64;
+#pragma omp parallel for schedule(static)
+      for(int lb=0; lb<N; lb+=TL){ int le=(lb+TL<N)?lb+TL:N;
+        for(int ib=0; ib<K; ib+=TI){ int ie=(ib+TI<K)?ib+TI:K;
+          for(int l=lb; l<le; l++){ uint8_t *out=donors+(size_t)l*K;
+            for(int i=ib; i<ie; i++) out[i]=(uint8_t)existing_h[i][l]; } } } }
     uint8_t *rh=cf_xmalloc(N); for(int l=0;l<N;l++) rh[l]=(uint8_t)newh[l];
 
     Groups Gr=build_groups_adaptive(Ustar);


### PR DESCRIPTION
## Summary

`cpfold_perpop` rebuilds a locus-major donor buffer from the hap-major `existing_h` on every call. The naive transpose writes `donors` strided by `K` (one byte touched per cache line), which profiling showed was about half of the chromosome-scale `-fold` wall-clock.

This cache-blocks the transpose:

- parallelize over **disjoint locus tiles** (`#pragma omp parallel for` over `lb`), so no two threads write the same byte - no false sharing on the shared `donors` buffer;
- block the donor dimension by one cache line (`TI=64`) so each line is filled contiguously instead of strided;
- `TL=512` keeps the read block (`TI*TL` = 32 KiB) inside L1.

The tile sizes are an L1-fit robustness choice, not a machine-tuned constant: wall-clock is flat across `TL` in 256..4096 on the hardware tested.

Builds on the `-fold` painter (#11).

## Correctness

Pure data-layout change - **output is byte-identical**. The locus-tile partition is disjoint (each thread owns a distinct range of loci), and the `parallel for` carries a full implicit barrier before the buffer is read, so there is no data race.

## Performance

About **1.35x** on a chr11-scale fold single-threaded (the transpose was ~half the wall-clock). The transpose is now also parallelized, so it scales further with `-fold`'s recipient-level threads.

## Validation

- `make check` 65/65: byte-identical chunkcounts vs the pre-change transpose.
- ASAN clean (the new tiling index math is in-bounds).
- Race-free under TSAN: zero same-region worker-vs-worker conflicts, confirming the disjoint partition. The only reports are the known GCC-libgomp uninstrumented-barrier false positives (a post-region main read vs the worker writes), which an OpenMP-aware tool (Archer) does not flag.
